### PR TITLE
BUG: Adds get-nodes to http handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,5 +25,5 @@ func main() {
 
 	swarmListener.Run()
 	serve := NewServe(swarmListener, l)
-	l.Fatal(serve.Run())
+	l.Fatal(Run(serve))
 }


### PR DESCRIPTION
Fixes one of the errors in https://github.com/docker-flow/docker-flow-swarm-listener/issues/3.