### PR TITLE
ENH: Notify services after notifying nodes

### DIFF
--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -327,8 +327,10 @@ func (l *SwarmListener) processNodeEventCreate(event Event) {
 	for {
 		select {
 		case <-doneChan:
+			l.NotifyServices(true)
 			return
 		case <-ctx.Done():
+			l.NotifyServices(true)
 			return
 		}
 	}
@@ -354,8 +356,10 @@ func (l *SwarmListener) processNodeEventRemove(event Event) {
 	for {
 		select {
 		case <-doneChan:
+			l.NotifyServices(true)
 			return
 		case <-ctx.Done():
+			l.NotifyServices(true)
 			return
 		}
 	}

--- a/service/task.go
+++ b/service/task.go
@@ -92,6 +92,8 @@ func GetTaskList(ctx context.Context, client *client.Client, serviceID string) (
 	taskFilter := filters.NewArgs()
 	taskFilter.Add("service", serviceID)
 	taskFilter.Add("_up-to-date", "true")
+	taskFilter.Add("desired-state", "running")
+	taskFilter.Add("desired-state", "accepted")
 
 	getUpToDateTasks := func() ([]swarm.Task, error) {
 		return client.TaskList(ctx, types.TaskListOptions{Filters: taskFilter})


### PR DESCRIPTION
Addresses #9

1. Sends service notifications after sending node notifications.
2. Only include tasks that are accepted or running.