### PR TITLE
ENH: Adds service polling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV DF_DOCKER_HOST="unix:///var/run/docker.sock" \
     DF_RETRY="50" \
     DF_RETRY_INTERVAL="5" \
     DF_NOTIFY_LABEL="com.df.notify" \
-    DF_INCLUDE_NODE_IP_INFO="false"
+    DF_INCLUDE_NODE_IP_INFO="false" \
+    DF_SERVICE_POLLING_INTERVAL="-1" \
+    DF_USE_DOCKER_SERVICE_EVENTS="true"
 
 EXPOSE 8080
 

--- a/args.go
+++ b/args.go
@@ -6,12 +6,14 @@ import (
 )
 
 type args struct {
-	Retry         int
-	RetryInterval int
+	ServicePollingInterval int
+	Retry                  int
+	RetryInterval          int
 }
 
 func getArgs() *args {
 	return &args{
+		ServicePollingInterval: getValue(-1, "DF_SERVICE_POLLING_INTERVAL"),
 		Retry:         getValue(1, "DF_RETRY"),
 		RetryInterval: getValue(0, "DF_RETRY_INTERVAL"),
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,3 +13,5 @@ The following environment variables can be used when creating the `swarm-listene
 |DF_NOTIFY_REMOVE_NODE_URL |Comma separated list of URLs that will be used to send notification requests when a node is remove.<br>**Example**: `url1,url2`|
 |DF_RETRY           |Number of notification request retries<br>**Default**: `50`<br>**Example**: `100`|
 |DF_RETRY_INTERVAL  |Time between each notificationo request retry, in seconds.<br>**Default**: `5`<br>**Example**:`10`|
+|DF_SERVICE_POLLING_INTERVAL |Time between each service polling request, in seconds. When this value is set less than or equal to zero, service polling is disabled.<br>**Default**: `-1`<br>**Example**:`20`|
+|DF_USE_DOCKER_SERVICE_EVENTS|Use docker events api to get service updates.<br>**Default**:`true`|

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	l.Printf("Starting Docker Flow: Swarm Listener")
 	args := getArgs()
-	swarmListener, err := service.NewSwarmListenerFromEnv(args.Retry, args.RetryInterval, l)
+	swarmListener, err := service.NewSwarmListenerFromEnv(args.Retry, args.RetryInterval, args.ServicePollingInterval, l)
 	if err != nil {
 		l.Printf("Failed to initialize Docker Flow: Swarm Listener")
 		l.Printf("ERROR: %v", err)

--- a/service/mocks.go
+++ b/service/mocks.go
@@ -67,6 +67,11 @@ func (m *swarmServiceCacherMock) InsertAndCheck(ss SwarmServiceMini) bool {
 	return args.Bool(0)
 }
 
+func (m *swarmServiceCacherMock) IsNewOrUpdated(ss SwarmServiceMini) bool {
+	args := m.Called(ss)
+	return args.Bool(0)
+}
+
 func (m *swarmServiceCacherMock) Delete(ID string) {
 	m.Called(ID)
 }
@@ -79,6 +84,11 @@ func (m *swarmServiceCacherMock) Get(ID string) (SwarmServiceMini, bool) {
 func (m *swarmServiceCacherMock) Len() int {
 	args := m.Called()
 	return args.Int(0)
+}
+
+func (m *swarmServiceCacherMock) Keys() map[string]struct{} {
+	args := m.Called()
+	return args.Get(0).(map[string]struct{})
 }
 
 type nodeListeningMock struct {
@@ -135,4 +145,12 @@ func (m *notifyDistributorMock) HasServiceListeners() bool {
 
 func (m *notifyDistributorMock) HasNodeListeners() bool {
 	return m.Called().Bool(0)
+}
+
+type swarmServicePollingMock struct {
+	mock.Mock
+}
+
+func (m *swarmServicePollingMock) Run(eventChan chan<- Event) {
+	m.Called(eventChan)
 }

--- a/service/servicecache_test.go
+++ b/service/servicecache_test.go
@@ -132,9 +132,44 @@ func (s *SwarmServiceCacheTestSuite) Test_GetAndRemove_InCache_ReturnsSwarmServi
 	s.Cache.Delete(s.SSMini.ID)
 	s.AssertNotInCache(s.SSMini)
 	s.Equal(s.SSMini, removedSSMini)
+}
+
+func (s *SwarmServiceCacheTestSuite) Test_Keys() {
+	s.Cache.InsertAndCheck(s.SSMini)
+	s.AssertInCache(s.SSMini)
+
+	keys := s.Cache.Keys()
+
+	s.Require().Len(keys, 1)
+	s.Contains(keys, s.SSMini.ID)
 
 }
 
+func (s *SwarmServiceCacheTestSuite) Test_IsNewOrUpdated_ServiceInCache() {
+	s.Cache.InsertAndCheck(s.SSMini)
+	s.AssertInCache(s.SSMini)
+
+	newOrUpdated := s.Cache.IsNewOrUpdated(s.SSMini)
+	s.False(newOrUpdated)
+}
+
+func (s *SwarmServiceCacheTestSuite) Test_IsNewOrUpdated_ServiceNotInCache() {
+	newOrUpdated := s.Cache.IsNewOrUpdated(s.SSMini)
+	s.True(newOrUpdated)
+}
+
+func (s *SwarmServiceCacheTestSuite) Test_IsNewOrUpdated_ServiceIsDifferentCache() {
+
+	s.Cache.InsertAndCheck(s.SSMini)
+	s.AssertInCache(s.SSMini)
+
+	anotherSSMini := getNewSwarmServiceMini()
+	anotherSSMini.Name = "anotherName"
+
+	newOrUpdated := s.Cache.IsNewOrUpdated(anotherSSMini)
+	s.True(newOrUpdated)
+
+}
 func (s *SwarmServiceCacheTestSuite) Test_GetAndRemove_NotInCache_ReturnsFalse() {
 
 	_, ok := s.Cache.Get(s.SSMini.ID)

--- a/service/servicepoller.go
+++ b/service/servicepoller.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// SwarmServicePolling provides an interface for polling service changes
+type SwarmServicePolling interface {
+	Run(eventChan chan<- Event)
+}
+
+// SwarmServicePoller implements `SwarmServicePoller`
+type SwarmServicePoller struct {
+	SSClient        SwarmServiceInspector
+	SSCache         SwarmServiceCacher
+	PollingInterval int
+	MinifyFunc      func(SwarmService) SwarmServiceMini
+	Log             *log.Logger
+}
+
+// NewSwarmServicePoller creates a new `SwarmServicePoller`
+func NewSwarmServicePoller(
+	ssClient SwarmServiceInspector,
+	ssCache SwarmServiceCacher,
+	pollingInterval int,
+	minifyFunc func(SwarmService) SwarmServiceMini,
+	log *log.Logger,
+) *SwarmServicePoller {
+	return &SwarmServicePoller{
+		SSClient:        ssClient,
+		SSCache:         ssCache,
+		PollingInterval: pollingInterval,
+		MinifyFunc:      minifyFunc,
+		Log:             log,
+	}
+}
+
+// Run starts poller and places events onto `eventChan`
+func (s SwarmServicePoller) Run(
+	eventChan chan<- Event) {
+
+	if s.PollingInterval <= 0 {
+		return
+	}
+
+	s.Log.Printf("Polling for Service Changes")
+	time.Sleep(time.Duration(s.PollingInterval) * time.Second)
+	for {
+		services, err := s.SSClient.SwarmServiceList(context.Background())
+		if err != nil {
+			s.Log.Printf("ERROR (SwarmServicePolling): %v", err)
+		} else {
+			nowTimeNano := time.Now().UTC().UnixNano()
+			keys := s.SSCache.Keys()
+			for _, ss := range services {
+				delete(keys, ss.ID)
+				ssMini := s.MinifyFunc(ss)
+				if s.SSCache.IsNewOrUpdated(ssMini) {
+					eventChan <- Event{
+						Type:     EventTypeCreate,
+						ID:       ss.ID,
+						TimeNano: nowTimeNano,
+						UseCache: true,
+					}
+				}
+			}
+
+			// Remaining keys are removal events
+			for k := range keys {
+				eventChan <- Event{
+					Type:     EventTypeRemove,
+					ID:       k,
+					TimeNano: nowTimeNano,
+					UseCache: true,
+				}
+			}
+		}
+		time.Sleep(time.Duration(s.PollingInterval) * time.Second)
+	}
+}

--- a/service/servicepoller_test.go
+++ b/service/servicepoller_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"bytes"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ServicePollerTestSuite struct {
+	suite.Suite
+	SSClientMock *swarmServiceInspector
+	SSCacheMock  *swarmServiceCacherMock
+	MinifyFunc   func(ss SwarmService) SwarmServiceMini
+
+	SSPoller *SwarmServicePoller
+	Logger   *log.Logger
+	LogBytes *bytes.Buffer
+}
+
+func TestServicePollerUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(ServicePollerTestSuite))
+}
+
+func (s *ServicePollerTestSuite) SetupTest() {
+	s.SSClientMock = new(swarmServiceInspector)
+	s.SSCacheMock = new(swarmServiceCacherMock)
+
+	s.MinifyFunc = func(ss SwarmService) SwarmServiceMini {
+		return MinifySwarmService(ss, "com.df.notify", "com.df.scrapeNetwork")
+	}
+	s.LogBytes = new(bytes.Buffer)
+	s.Logger = log.New(s.LogBytes, "", 0)
+
+	s.SSPoller = NewSwarmServicePoller(
+		s.SSClientMock,
+		s.SSCacheMock,
+		1,
+		s.MinifyFunc,
+		s.Logger,
+	)
+}
+
+func (s *ServicePollerTestSuite) Test_Run_NoCache() {
+
+	expServices := []SwarmService{
+		{swarm.Service{ID: "serviceID1"}, nil},
+		{swarm.Service{ID: "serviceID2"}, nil},
+	}
+	keys := map[string]struct{}{}
+	miniSS1 := SwarmServiceMini{
+		ID: "serviceID1", Labels: map[string]string{}}
+	miniSS2 := SwarmServiceMini{
+		ID: "serviceID2", Labels: map[string]string{}}
+
+	eventChan := make(chan Event)
+
+	s.SSClientMock.
+		On("SwarmServiceList", mock.AnythingOfType("*context.emptyCtx")).Return(expServices, nil)
+	s.SSCacheMock.
+		On("Keys").Return(keys).
+		On("IsNewOrUpdated", miniSS1).Return(true).
+		On("IsNewOrUpdated", miniSS2).Return(true)
+
+	go s.SSPoller.Run(eventChan)
+
+	timeout := time.NewTimer(time.Second * 5).C
+	eventsNum := 0
+
+	for {
+		if eventsNum == 2 {
+			break
+		}
+		select {
+		case event := <-eventChan:
+			s.Require().Equal(EventTypeCreate, event.Type)
+			eventsNum++
+		case <-timeout:
+			s.FailNow("Timeout")
+		}
+	}
+
+	s.Equal(2, eventsNum)
+	s.SSClientMock.AssertExpectations(s.T())
+	s.SSCacheMock.AssertExpectations(s.T())
+}
+
+func (s *ServicePollerTestSuite) Test_Run_HalfInCache() {
+
+	expServices := []SwarmService{
+		{swarm.Service{ID: "serviceID1"}, nil},
+		{swarm.Service{ID: "serviceID2"}, nil},
+	}
+	miniSS1 := SwarmServiceMini{
+		ID: "serviceID1", Labels: map[string]string{}}
+	miniSS2 := SwarmServiceMini{
+		ID: "serviceID2", Labels: map[string]string{}}
+
+	keys := map[string]struct{}{}
+	keys["serviceID1"] = struct{}{}
+
+	eventChan := make(chan Event)
+
+	s.SSClientMock.
+		On("SwarmServiceList", mock.AnythingOfType("*context.emptyCtx")).Return(expServices, nil)
+	s.SSCacheMock.
+		On("Keys").Return(keys).
+		On("IsNewOrUpdated", miniSS1).Return(false).
+		On("IsNewOrUpdated", miniSS2).Return(true)
+
+	go s.SSPoller.Run(eventChan)
+
+	timeout := time.NewTimer(time.Second * 5).C
+	var eventCreate *Event
+	eventsNum := 0
+
+	for {
+		if eventsNum == 1 {
+			break
+		}
+		select {
+		case event := <-eventChan:
+			if event.ID == "serviceID2" {
+				eventCreate = &event
+			}
+			eventsNum++
+		case <-timeout:
+			s.Fail("Timeout")
+			return
+		}
+	}
+
+	s.Equal(1, eventsNum)
+	s.Require().NotNil(eventCreate)
+
+	s.Equal("serviceID2", eventCreate.ID)
+	s.SSClientMock.AssertExpectations(s.T())
+	s.SSCacheMock.AssertExpectations(s.T())
+}
+
+func (s *ServicePollerTestSuite) Test_Run_MoreInCache() {
+
+	expServices := []SwarmService{
+		{swarm.Service{ID: "serviceID1"}, nil},
+		{swarm.Service{ID: "serviceID2"}, nil},
+	}
+	miniSS1 := SwarmServiceMini{
+		ID: "serviceID1", Labels: map[string]string{}}
+	miniSS2 := SwarmServiceMini{
+		ID: "serviceID2", Labels: map[string]string{}}
+
+	keys := map[string]struct{}{}
+	keys["serviceID1"] = struct{}{}
+	keys["serviceID2"] = struct{}{}
+	keys["serviceID3"] = struct{}{}
+
+	eventChan := make(chan Event)
+
+	s.SSClientMock.
+		On("SwarmServiceList", mock.AnythingOfType("*context.emptyCtx")).Return(expServices, nil)
+	s.SSCacheMock.
+		On("Keys").Return(keys).
+		On("IsNewOrUpdated", miniSS1).Return(true).
+		On("IsNewOrUpdated", miniSS2).Return(false)
+
+	go s.SSPoller.Run(eventChan)
+
+	timeout := time.NewTimer(time.Second * 5).C
+	var eventCreate *Event
+	var eventRemove *Event
+	eventsNum := 0
+
+	for {
+		if eventsNum == 2 {
+			break
+		}
+		select {
+		case event := <-eventChan:
+			if event.ID == "serviceID1" {
+				eventCreate = &event
+			} else if event.ID == "serviceID3" {
+				eventRemove = &event
+			}
+			eventsNum++
+		case <-timeout:
+			s.Fail("Timeout")
+			return
+		}
+	}
+
+	s.Equal(2, eventsNum)
+	s.Require().NotNil(eventCreate)
+	s.Require().NotNil(eventRemove)
+
+	s.Equal("serviceID1", eventCreate.ID)
+	s.Equal("serviceID3", eventRemove.ID)
+	s.SSClientMock.AssertExpectations(s.T())
+	s.SSCacheMock.AssertExpectations(s.T())
+}

--- a/service/swarmlistener_test.go
+++ b/service/swarmlistener_test.go
@@ -22,6 +22,8 @@ type SwarmListenerTestSuite struct {
 	NodeClientMock    *nodeInspectorMock
 	NodeCacheMock     *nodeCacherMock
 
+	SSPoller *swarmServicePollingMock
+
 	NotifyDistributorMock *notifyDistributorMock
 
 	SwarmListener *SwarmListener
@@ -41,6 +43,9 @@ func (s *SwarmListenerTestSuite) SetupTest() {
 	s.NodeListeningMock = new(nodeListeningMock)
 	s.NodeClientMock = new(nodeInspectorMock)
 	s.NodeCacheMock = new(nodeCacherMock)
+
+	s.SSPoller = new(swarmServicePollingMock)
+
 	s.NotifyDistributorMock = new(notifyDistributorMock)
 	s.LogBytes = new(bytes.Buffer)
 	s.Logger = log.New(s.LogBytes, "", 0)
@@ -49,6 +54,7 @@ func (s *SwarmListenerTestSuite) SetupTest() {
 		s.SSListenerMock,
 		s.SSClientMock,
 		s.SSCacheMock,
+		s.SSPoller,
 		make(chan Event),
 		make(chan Notification),
 		s.NodeListeningMock,
@@ -62,6 +68,7 @@ func (s *SwarmListenerTestSuite) SetupTest() {
 		NewCancelManager(true),
 		NewCancelManager(true),
 		false,
+		true,
 		"com.df.notify",
 		"com.docker.stack.namespace",
 		s.Logger,
@@ -90,6 +97,9 @@ func (s *SwarmListenerTestSuite) Test_Run_ServicesChannel() {
 		On("HasServiceListeners").Return(true).
 		On("HasNodeListeners").Return(false).
 		On("Run", mock.AnythingOfType("<-chan service.Notification"), mock.AnythingOfType("<-chan service.Notification"))
+	s.SSPoller.
+		On("Run", mock.AnythingOfType("chan<- service.Event"))
+
 	s.SwarmListener.Run()
 
 	go func() {
@@ -149,6 +159,7 @@ func (s *SwarmListenerTestSuite) Test_Run_ServicesChannel() {
 	s.SSClientMock.AssertExpectations(s.T())
 	s.SSCacheMock.AssertExpectations(s.T())
 	s.NotifyDistributorMock.AssertExpectations(s.T())
+	s.SSPoller.AssertExpectations(s.T())
 
 }
 


### PR DESCRIPTION
Addresses https://github.com/docker-flow/docker-flow-swarm-listener/issues/5

This PR introduces two new environment variables: 

1.  If `DF_SERVICE_POLLING_INTERVAL>0`, service polling is activated with that number of seconds between polling intervals. If `DF_SERVICE_POLLING_INTERVAL<=0`, service polling is not used. The default is `DF_SERVICE_POLLING_INTERVAL=-1`.

2. If `DF_USE_DOCKER_SERVICE_EVENTS=true`, the docker events api will be used to listen for events. If `DF_USE_DOCKER_SERVICE_EVENTS=false`, the docker events api is not used. The default is `DF_USE_DOCKER_SERVICE_EVENTS=true`.
