### PR TITLE
No address in node info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV DF_DOCKER_HOST="unix:///var/run/docker.sock" \
     DF_RETRY_INTERVAL="5" \
     DF_NOTIFY_LABEL="com.df.notify" \
     DF_INCLUDE_NODE_IP_INFO="false" \
+    DF_NODE_IP_INFO_INCLUDES_TASK_ADDRESS="true" \
     DF_SERVICE_POLLING_INTERVAL="-1" \
     DF_USE_DOCKER_SERVICE_EVENTS="true" \
     DF_NODE_POLLING_INTERVAL="-1" \

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,7 @@ The following environment variables can be used when creating the `swarm-listene
 |DF_NOTIFY_CREATE_SERVICE_METHOD|Comma separated list of HTTP methods used to send requests to its corresponding `DF_NOTIFY_CREATE_SERVICE_URL`. If the number of comma separated list of HTTP methods is less than the number of create service URLs, then the last HTTP method in the list will be used for the rest of the services.<br>**Default**: `GET` <br>**Example**: `GET,POST`|
 |DF_NOTIFY_REMOVE_SERVICE_METHOD|Comma separated list of HTTP methods used to send requests to its corresponding `DF_NOTIFY_REMOVE_SERVICE_URL`. If the number of comma separated list of HTTP methods is less than the number of remove service URLs, then the last HTTP method in the list will be used for the rest of the services<br>**Default**: `GET` <br>**Example**: `GET,POST`|
 |DF_INCLUDE_NODE_IP_INFO|Include node and ip information for service in notification.<br>**Default**:`false`|
+|DF_NODE_IP_INFO_INCLUDES_TASK_ADDRESS|Include task ip address when `DF_INCLUDE_NODE_IP_INFO` is true.<br>**Default**: `true`|
 |DF_NOTIFY_CREATE_NODE_URL |Comma separated list of URLs that will be used to send notification requests when a node is created or updated.<br>**Example**: `url1,url2`|
 |DF_NOTIFY_REMOVE_NODE_URL |Comma separated list of URLs that will be used to send notification requests when a node is remove.<br>**Example**: `url1,url2`|
 |DF_RETRY           |Number of notification request retries<br>**Default**: `50`<br>**Example**: `100`|

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -57,7 +57,7 @@ func (s *SwarmServiceClientTestSuite) SetupTest() {
 	s.LogBytes = new(bytes.Buffer)
 	s.Logger = log.New(s.LogBytes, "", 0)
 
-	s.SClient = NewSwarmServiceClient(c, "com.df.notify=true", "com.df.scrapeNetwork", "", s.Logger)
+	s.SClient = NewSwarmServiceClient(c, "com.df.notify=true", "com.df.scrapeNetwork", "", true, s.Logger)
 }
 
 func (s *SwarmServiceClientTestSuite) TearDownSuite() {

--- a/service/servicepoller.go
+++ b/service/servicepoller.go
@@ -64,7 +64,10 @@ func (s SwarmServicePoller) Run(
 				delete(keys, ss.ID)
 
 				if s.IncludeNodeInfo {
-					if nodeInfo, err := s.SSClient.GetNodeInfo(ctx, ss); err == nil {
+					nodeInfo, err := s.SSClient.GetNodeInfo(ctx, ss)
+					if err != nil {
+						s.Log.Printf("ERROR: GetServicesParameters, %v", err)
+					} else {
 						ss.NodeInfo = nodeInfo
 					}
 				}

--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -126,6 +126,10 @@ func NewSwarmListenerFromEnv(
 	if err != nil {
 		includeNodeInfo = false
 	}
+	nodeIPInfoIncludesTaskAddress, err := strconv.ParseBool(os.Getenv("DF_NODE_IP_INFO_INCLUDES_TASK_ADDRESS"))
+	if err != nil {
+		nodeIPInfoIncludesTaskAddress = true
+	}
 	useDockerServiceEvents, err := strconv.ParseBool(os.Getenv("DF_USE_DOCKER_SERVICE_EVENTS"))
 	if err != nil {
 		useDockerServiceEvents = false
@@ -166,7 +170,7 @@ func NewSwarmListenerFromEnv(
 	var nodeStopEventChan chan struct{}
 
 	ssClient := NewSwarmServiceClient(
-		dockerClient, ignoreKey, "com.df.scrapeNetwork", serviceNamePrefix, logger)
+		dockerClient, ignoreKey, "com.df.scrapeNetwork", serviceNamePrefix, nodeIPInfoIncludesTaskAddress, logger)
 	nodeClient := NewNodeClient(dockerClient)
 
 	nodeInfraCreated := false

--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -682,9 +682,13 @@ func (l SwarmListener) GetServicesParameters(ctx context.Context) ([]map[string]
 		go func(ss SwarmService) {
 			defer wg.Done()
 			if l.IncludeNodeInfo {
-				if nodeInfo, err := l.SSClient.GetNodeInfo(ctx, ss); err == nil {
+				nodeInfo, err := l.SSClient.GetNodeInfo(ctx, ss)
+				if err != nil {
+					l.Log.Printf("ERROR: GetServicesParameters, %v", err)
+				} else {
 					ss.NodeInfo = nodeInfo
 				}
+
 			}
 			ssm := MinifySwarmService(ss, l.IgnoreKey, l.IncludeKey)
 			newParams := GetSwarmServiceMiniCreateParameters(ssm)


### PR DESCRIPTION
Adds `DF_NODE_IP_INFO_INCLUDES_TASK_ADDRESS` flag. By default, this is set to true, which means all the task ips are sent with node information.

When `DF_INCLUDE_NODE_IP_INFO` is true and `DF_NODE_IP_INFO_INCLUDES_TASK_ADDRESS` is false, DFSL will not look for the address, and only return the nodes the service is running on.