### PR TITLE
ENH: Handles events more deterministically

### DIFF
--- a/service/swarmlistener_test.go
+++ b/service/swarmlistener_test.go
@@ -58,11 +58,13 @@ func (s *SwarmListenerTestSuite) SetupTest() {
 		s.SSCacheMock,
 		s.SSPollerMock,
 		make(chan Event),
+		make(chan Event),
 		make(chan Notification),
 		s.NodeListeningMock,
 		s.NodeClientMock,
 		s.NodeCacheMock,
 		s.NodePollerMock,
+		make(chan Event),
 		make(chan Event),
 		make(chan Notification),
 		s.NotifyDistributorMock,
@@ -274,7 +276,7 @@ func (s *SwarmListenerTestSuite) Test_NotifyServices_WithCache() {
 			break
 		}
 		select {
-		case e := <-s.SwarmListener.SSEventChan:
+		case e := <-s.SwarmListener.SSInternalEventChan:
 			s.True(e.ConsultCache)
 			eventCnt++
 		case <-timeout:
@@ -313,7 +315,7 @@ func (s *SwarmListenerTestSuite) Test_NotifyServices_WithoutCache() {
 			break
 		}
 		select {
-		case e := <-s.SwarmListener.SSEventChan:
+		case e := <-s.SwarmListener.SSInternalEventChan:
 			s.False(e.ConsultCache)
 			eventCnt++
 		case <-timeout:
@@ -349,7 +351,7 @@ func (s *SwarmListenerTestSuite) Test_NotifyNodes_WithoutCache() {
 			break
 		}
 		select {
-		case e := <-s.SwarmListener.NodeEventChan:
+		case e := <-s.SwarmListener.NodeInteralEventChan:
 			s.False(e.ConsultCache)
 			eventCnt++
 		case <-timeout:
@@ -385,7 +387,7 @@ func (s *SwarmListenerTestSuite) Test_NotifyNodes_WithCache() {
 			break
 		}
 		select {
-		case e := <-s.SwarmListener.NodeEventChan:
+		case e := <-s.SwarmListener.NodeInteralEventChan:
 			s.True(e.ConsultCache)
 			eventCnt++
 		case <-timeout:
@@ -448,7 +450,7 @@ func (s *SwarmListenerTestSuite) Test_GetServices_WithoutNodeInfo_OneServiceNotR
 			break
 		}
 		select {
-		case e := <-s.SwarmListener.SSEventChan:
+		case e := <-s.SwarmListener.SSInternalEventChan:
 			event = &e
 		case <-timeout:
 			s.FailNow("Timeout")

--- a/service/swarmlistener_test.go
+++ b/service/swarmlistener_test.go
@@ -105,7 +105,6 @@ func (s *SwarmListenerTestSuite) Test_Run_ServicesChannel() {
 		On("Get", "serviceID2").Return(ss2m, true).
 		On("Len").Return(2)
 	s.NotifyDistributorMock.
-		On("HasServiceListeners").Return(true).
 		On("Run", mock.AnythingOfType("<-chan service.Notification"), mock.AnythingOfType("<-chan service.Notification"))
 	s.SSPollerMock.
 		On("Run", mock.AnythingOfType("chan<- service.Event"))
@@ -196,7 +195,6 @@ func (s *SwarmListenerTestSuite) Test_Run_NodeChannel() {
 	s.NodeCacheMock.On("InsertAndCheck", n1m).Return(true).
 		On("Get", "nodeID2").Return(n2m, true)
 	s.NotifyDistributorMock.
-		On("HasServiceListeners").Return(false).
 		On("Run", mock.AnythingOfType("<-chan service.Notification"), mock.AnythingOfType("<-chan service.Notification"))
 	s.NodePollerMock.
 		On("Run", mock.AnythingOfType("chan<- service.Event"))


### PR DESCRIPTION
When services are placed on event queue by a user, it may result in an incorrect state.

For example, if a user calls `NotifyService`, it sends events to the event channel to be processed. On the way to being processed, the service may have been removed. This leads to a race condition. If the remove notification gets sent first, then the user generated CREATE notification would lead to an incorrect state. 

I admit this is a pretty tiny window for this race condition to happen, but it is possible.

This PR attempts to add a internal event channel, so that events coming from the docker event api or polling can be paused, while the user created notifications can be processed first.