### PR TITLE
BUG: Fixes tiny opening for a race condition

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -61,7 +61,7 @@ func attachRoutes(s server) *http.ServeMux {
 
 // NotifyServices notifies all configured endpoints of new, updated, or removed services
 func (m Serve) NotifyServices(w http.ResponseWriter, req *http.Request) {
-	m.SwarmListener.NotifyServices(false)
+	go m.SwarmListener.NotifyServices(false)
 	js, _ := json.Marshal(Response{Status: "OK"})
 	httpWriterSetContentType(w, "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/serve_test.go
+++ b/serve_test.go
@@ -126,7 +126,6 @@ func (s *ServerTestSuite) Test_NotifyServices_ReturnsStatus200() {
 
 	s.RWMock.AssertCalled(s.T(), "WriteHeader", 200)
 	s.RWMock.AssertCalled(s.T(), "Write", []byte(expected))
-	s.SLMock.AssertExpectations(s.T())
 }
 
 func (s *ServerTestSuite) Test_NotifyServices_SetsContentTypeToJSON() {
@@ -143,7 +142,6 @@ func (s *ServerTestSuite) Test_NotifyServices_SetsContentTypeToJSON() {
 	srv.NotifyServices(s.RWMock, req)
 
 	s.Equal("application/json", actual)
-	s.SLMock.AssertExpectations(s.T())
 }
 
 // GetServices

--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -544,11 +544,9 @@ func (l SwarmListener) NotifyServices(consultCache bool) {
 	}
 
 	nowTimeNano := time.Now().UTC().UnixNano()
-	go func() {
-		for _, s := range services {
-			l.placeOnEventChan(l.SSInternalEventChan, EventTypeCreate, s.ID, nowTimeNano, consultCache)
-		}
-	}()
+	for _, s := range services {
+		l.placeOnEventChan(l.SSInternalEventChan, EventTypeCreate, s.ID, nowTimeNano, consultCache)
+	}
 }
 
 // NotifyNodes places all services on queue to notify serivces on node events
@@ -565,11 +563,9 @@ func (l SwarmListener) NotifyNodes(consultCache bool) {
 	}
 
 	nowTimeNano := time.Now().UTC().UnixNano()
-	go func() {
-		for _, n := range nodes {
-			l.placeOnEventChan(l.NodeInteralEventChan, EventTypeCreate, n.ID, nowTimeNano, consultCache)
-		}
-	}()
+	for _, n := range nodes {
+		l.placeOnEventChan(l.NodeInteralEventChan, EventTypeCreate, n.ID, nowTimeNano, consultCache)
+	}
 }
 
 func (l SwarmListener) placeOnNotificationChan(notiChan chan<- Notification, eventType EventType, timeNano int64, ID string, parameters string, errorChan chan error) {
@@ -629,11 +625,9 @@ func (l *SwarmListener) CompletelyNotifyServices() {
 			ssm := MinifySwarmService(ss, l.IgnoreKey, l.IncludeKey)
 			params := GetSwarmServiceMiniRemoveParameters(ssm)
 			paramsEncoded := ConvertMapStringStringToURLValues(params).Encode()
-			go func(params string, ID string) {
-				l.placeOnNotificationChan(
-					l.SSNotificationChan, EventTypeRemove, nowTimeNano, ID, params, errChan)
-				l.placeOnEventChan(l.SSInternalEventChan, EventTypeCreate, ID, nowTimeNano, false)
-			}(paramsEncoded, ssm.ID)
+			l.placeOnNotificationChan(
+				l.SSNotificationChan, EventTypeRemove, nowTimeNano, ssm.ID, paramsEncoded, errChan)
+			l.placeOnEventChan(l.SSInternalEventChan, EventTypeCreate, ssm.ID, nowTimeNano, false)
 			continue
 		}
 
@@ -642,11 +636,8 @@ func (l *SwarmListener) CompletelyNotifyServices() {
 		l.SSCache.InsertAndCheck(ssm)
 		params := GetSwarmServiceMiniCreateParameters(ssm)
 		paramsEncoded := ConvertMapStringStringToURLValues(params).Encode()
-
-		go func(params string, ID string) {
-			l.placeOnNotificationChan(
-				l.SSNotificationChan, EventTypeCreate, nowTimeNano, ID, params, errChan)
-		}(paramsEncoded, ssm.ID)
+		l.placeOnNotificationChan(
+			l.SSNotificationChan, EventTypeCreate, nowTimeNano, ssm.ID, paramsEncoded, errChan)
 	}
 	l.startEventChannels()
 


### PR DESCRIPTION
Placing the notifications and events serially on their respective queues, makes it so 100% of the time they are processed first before new events come in.

This works because events on the internal event channels and notifications on the notification channels are processed right away. In other words, there is always another go routine watching these channels and immediately creating another go routine to manage the event or notification.